### PR TITLE
Support Setting the Default Java Binary

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@
 # java_packages: []
 
 java_home: ""
+# Whether to set the installed Java binary as the default java. You will need
+# to set java_home too for this to be done
+java_set_default: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,3 +39,9 @@
     dest: /etc/profile.d/java_home.sh
     mode: 0644
   when: java_home is defined and java_home
+
+- name: Set the default Java
+  alternatives:
+    name: java
+    path: "{{ java_home }}/bin/java"
+  when: java_home is defined and java_home and java_set_default


### PR DESCRIPTION
Adds support for setting the default `java` binary.

Signed-off-by: Jason Rogena <jason@rogena.me>