### PR TITLE
Fix conditionals for Ansible 2.19+ compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,10 +38,10 @@
     src: java_home.sh.j2
     dest: /etc/profile.d/java_home.sh
     mode: 0644
-  when: java_home is defined and java_home
+  when: java_home is defined and java_home | length > 0
 
 - name: Set the default Java
   alternatives:
     name: java
     path: "{{ java_home }}/bin/java"
-  when: java_home is defined and java_home and java_set_default
+  when: java_home is defined and java_home | length > 0 and java_set_default


### PR DESCRIPTION
## Summary
- Replace string-as-boolean conditionals with `| length > 0` checks
- Ansible 2.19+ rejects `when: java_home is defined and java_home` because `java_home` is a string, not a boolean
- The fix uses `when: java_home is defined and java_home | length > 0` which works across all Ansible versions

## Test plan
- [ ] Verify `Set JAVA_HOME if configured` task is skipped when `java_home` is empty
- [ ] Verify `Set the default Java` task runs when `java_home` is set to a valid path
- [ ] Test with Ansible 2.19+